### PR TITLE
Add GM_addStyle

### DIFF
--- a/src/meta.js
+++ b/src/meta.js
@@ -12,5 +12,5 @@
 // @compatible      chrome
 // @compatible      opera
 // @run-at          document-end
-// @grant           GM_addStyle
+// @grant           none
 // ==/UserScript==

--- a/src/user.js
+++ b/src/user.js
@@ -1,6 +1,6 @@
 $inline('meta.js|trim')
 
-/* eslint-disable camelcase */
+// eslint-disable-next-line camelcase
 function GM_addStyle (css) {
   const style = document.createElement('style')
   style.type = 'text/css'
@@ -8,7 +8,6 @@ function GM_addStyle (css) {
   document.head.appendChild(style)
   return style
 }
-/* eslint-enable camelcase */
 
 GM_addStyle('.GM_favicon { margin-right: 0.5em; vertical-align: middle; }')
 

--- a/src/user.js
+++ b/src/user.js
@@ -1,10 +1,16 @@
 $inline('meta.js|trim')
 
-const css = '.GM_favicon { margin-right: 0.5em; vertical-align: middle; }'
-const style = document.createElement('style')
-style.type = 'text/css'
-style.textContent = css
-document.head.appendChild(style)
+/* eslint-disable camelcase */
+function GM_addStyle (css) {
+  const style = document.createElement('style')
+  style.type = 'text/css'
+  style.textContent = css
+  document.head.appendChild(style)
+  return style
+}
+/* eslint-enable camelcase */
+
+GM_addStyle('.GM_favicon { margin-right: 0.5em; vertical-align: middle; }')
 
 const observer = new window.MutationObserver(mutations => {
   mutations.forEach(mutation => {

--- a/src/user.js
+++ b/src/user.js
@@ -1,14 +1,10 @@
 $inline('meta.js|trim')
 
 const css = '.GM_favicon { margin-right: 0.5em; vertical-align: middle; }'
-if (typeof GM_addStyle === 'function') {
-  GM_addStyle(css)
-} else {
-  const style = document.createElement('style')
-  style.type = 'text/css'
-  style.textContent = css
-  document.head.appendChild(style)
-}
+const style = document.createElement('style')
+style.type = 'text/css'
+style.textContent = css
+document.head.appendChild(style)
 
 const observer = new window.MutationObserver(mutations => {
   mutations.forEach(mutation => {

--- a/src/user.js
+++ b/src/user.js
@@ -1,6 +1,14 @@
 $inline('meta.js|trim')
 
-GM_addStyle('.GM_favicon { margin-right: 0.5em; vertical-align: middle; }')
+const css = '.GM_favicon { margin-right: 0.5em; vertical-align: middle; }'
+if (typeof GM_addStyle === 'function') {
+  GM_addStyle(css)
+} else {
+  const style = document.createElement('style')
+  style.type = 'text/css'
+  style.textContent = css
+  document.head.appendChild(style)
+}
 
 const observer = new window.MutationObserver(mutations => {
   mutations.forEach(mutation => {


### PR DESCRIPTION
Since Greasemonkey 4.0+ seems not going to support `GM_addStyle` API, I added a polyfill for that.

> As of today, there is no support for: `GM_log` (use console.log), `GM_addStyle`, `GM_registerMenuCommand`, nor `GM_getResourceText`.
> — https://www.greasespot.net/2017/09/greasemonkey-4-for-script-authors.html
