### PR TITLE
Insert favicon correctly after Feedly updates

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -10,6 +10,11 @@ function GM_addStyle (css) {
 
 GM_addStyle('.gm-favicon { margin-right: 0.5em; vertical-align: middle; }')
 
+// Add forEach method to NodeList for legacy browsers.
+if (window.NodeList && !NodeList.prototype.forEach) {
+  NodeList.prototype.forEach = Array.prototype.forEach
+}
+
 const observer = new MutationObserver(mutations => {
   mutations.forEach(mutation => {
     const target = mutation.target

--- a/src/user.js
+++ b/src/user.js
@@ -29,19 +29,23 @@ function getFeedlyPage () {
   })
 }
 
-const observer = new MutationObserver(mutations => {
-  mutations.forEach(mutation => {
-    const target = mutation.target
-    if (target.classList.contains('entry') && target.querySelector('.gm-favicon') === null) {
-      const source = target.querySelector('a.source')
-      if (source !== null) {
+getFeedlyPage().then(page => {
+  const observer = new MutationObserver(mutations => {
+    const sources = new Set()
+    mutations.map(mutation => mutation.target).forEach(target => {
+      target.querySelectorAll('a.source[data-uri]').forEach(source => {
+        sources.add(source)
+      })
+    })
+    sources.forEach(source => {
+      if (source.querySelector('img.gm-favicon') === null) {
         const domain = source.href.replace(/^https?:\/\/([^/:]+).*/i, '$1')
         const favicon = document.createElement('img')
         favicon.src = `https://www.google.com/s2/favicons?domain=${domain}&alt=feed`
         favicon.classList.add('gm-favicon')
         source.insertAdjacentElement('afterbegin', favicon)
       }
-    }
+    })
   })
+  observer.observe(page, { childList: true, subtree: true })
 })
-observer.observe(document.getElementById('box'), { childList: true, subtree: true })

--- a/src/user.js
+++ b/src/user.js
@@ -15,6 +15,20 @@ if (window.NodeList && !NodeList.prototype.forEach) {
   NodeList.prototype.forEach = Array.prototype.forEach
 }
 
+function getFeedlyPage () {
+  return new Promise(resolve => {
+    const observer = new MutationObserver(mutations => {
+      mutations.map(mutation => mutation.target).forEach(target => {
+        if (target.id === 'feedlyPageFX') {
+          resolve(target)
+          observer.disconnect()
+        }
+      })
+    })
+    observer.observe(document.getElementById('box'), { childList: true, subtree: true })
+  })
+}
+
 const observer = new MutationObserver(mutations => {
   mutations.forEach(mutation => {
     const target = mutation.target


### PR DESCRIPTION
I found that favicons aren't inserted to the list after Feedly updated their page loading method. This PR makes this script use a new way to observe the entry list items and insert favicons correctly.
