### PR TITLE
Fix favicon display issue due to Feedly updates.

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -88,7 +88,7 @@ function createFavicon (url) {
 }
 
 awaitSelector('#feedlyPageFX', '#root').then(pages => {
-  waitAwaitSelector('a.entry__source--u0[href]', pages[0], sources => {
+  waitAwaitSelector('a.EntryMetadataSource[href]', pages[0], sources => {
     sources
       .filter(source => source.querySelector('.gm-favicon') === null)
       .forEach(source => {


### PR DESCRIPTION
Today, I found that the favicon is not displayed properly, so I fixed it.